### PR TITLE
Add command ``SspmEnergyTotal<relay>``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ All notable changes to this project will be documented in this file.
 - Command ``Json {<Tasmota commands>}`` to enable input of any command as JSON tokens (#14568)
 - Rule variable %color% (#14572)
 - Command ``SspmDisplay 1`` to display Sonoff SPM energy data in GUI for relays powered on only
-- Command ``SspmHistory<relay>`` to retrieve daily energy of last six month (as defined by ARM firmware)
+- Command ``SspmEnergyTotal<relay>`` to (p)reset Sonoff SPM total energy without today's energy
+- Command ``SspmHistory<relay>`` to retrieve Sonoff SPM daily energy up to last six month (as defined by ARM firmware)
 - Command ``SspmIAmHere<relay>`` to (faintly) blink Sonoff SPM-4Relay module error light of requested relay
-- Command ``SspmLog<relay> [x]`` to retrieve relay power state change and cause logging
+- Command ``SspmLog<relay> [x]`` to retrieve Sonoff SPM relay power state change and cause logging
 - Command ``SspmScan`` to rescan Sonoff SPM modbus
 - Support for MQ analog sensor for air quality by Francesco Adriani (#14581)
-- PWM auto-phasing for lights by default (new behavior) unless ``SetOption134 1``
+- Command ``SetOption134 1`` to disable PWM auto-phasing for lights by default (new behavior) (#14590)
 
 ### Changed
 - BME68x-Sensor-API library from v3.5.9 to v4.4.7

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -102,16 +102,18 @@ The latter links can be used for OTA upgrades too like ``OtaUrl http://ota.tasmo
 
 ## Changelog v2022.01.3
 ### Added
+- Command ``Json {<Tasmota commands>}`` to enable input of any command as JSON tokens [#14568](https://github.com/arendst/Tasmota/issues/14568)
+- Command ``SetOption44 1..100`` to set base tolerance percentage for matching incoming IR messages (default 25, max 100) [#14555](https://github.com/arendst/Tasmota/issues/14555)
+- Command ``SetOption134 1`` to disable PWM auto-phasing for lights by default (new behavior) [#14590](https://github.com/arendst/Tasmota/issues/14590)
 - Command ``SSerialConfig <serialconfig>`` to change Serial Bridge configuration
-- Command ``WebTime <start_pos>,<end_pos>`` to show part of date and/or time in web gui based on "2017-03-07T11:08:02-07:00"
 - Command ``SspmDisplay 1`` to display Sonoff SPM energy data in GUI for relays powered on only
-- Command ``SspmHistory<relay>`` to retrieve daily energy of last six month (as defined by ARM firmware)
+- Command ``SspmEnergyTotal<relay>`` to (p)reset Sonoff SPM total energy without today's energy
+- Command ``SspmHistory<relay>`` to retrieve Sonoff SPM daily energy up to last six month (as defined by ARM firmware)
 - Command ``SspmIAmHere<relay>`` to (faintly) blink Sonoff SPM-4Relay module error light of requested relay
-- Command ``SspmLog<relay> [x]`` to retrieve relay power state change and cause logging
+- Command ``SspmLog<relay> [x]`` to retrieve Sonoff SPM relay power state change and cause logging
 - Command ``SspmMap 2,1,..`` to map Sonoff SPM scanned module to physical module [#14281](https://github.com/arendst/Tasmota/issues/14281)
 - Command ``SspmScan`` to rescan Sonoff SPM modbus
-- Command ``SetOption44 1..100`` to set base tolerance percentage for matching incoming IR messages (default 25, max 100) [#14555](https://github.com/arendst/Tasmota/issues/14555)
-- Command ``Json {<Tasmota commands>}`` to enable input of any command as JSON tokens [#14568](https://github.com/arendst/Tasmota/issues/14568)
+- Command ``WebTime <start_pos>,<end_pos>`` to show part of date and/or time in web gui based on "2017-03-07T11:08:02-07:00"
 - Commands for ESP32 ethernet configuration ``EthIpAddress``, ``EthGateway``, ``EthSubnetmask``, ``EthDnsServer1`` and ``EthDnsServer2`` [#14385](https://github.com/arendst/Tasmota/issues/14385)
 - Support for Eastron SDM230 modBus energy meter [#13443](https://github.com/arendst/Tasmota/issues/13443)
 - PWM Dimmer two button support [#13993](https://github.com/arendst/Tasmota/issues/13993)


### PR DESCRIPTION
Add command ``SspmEnergyTotal<relay>`` to (p)reset Sonoff SPM total energy without today's energy

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
